### PR TITLE
End user improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # OME-Zarr Conversion Pipeline
 
-Nextflow pipeline which converts Bioformats-compatible images to [NGFF](https://github.com/ome/ngff) (e.g. OME-Zarr) format using [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw). 
+This Nextflow pipeline automates the conversion of [Bio-Formats-compatible images](https://bio-formats.readthedocs.io/en/v8.3.0/supported-formats.html) into the [Next Generation File Format (NGFF)](https://github.com/ome/ngff) (a.k.a. OME-Zarr) using [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw). 
 
-Why not just use bioformats2raw directly? This pipeline encapsulates all the dependencies, so you don't need to install Java, blosc, etc. It also lets you distribute work on any HPC cluster.
+## Why use this pipeline instead of bioformats2raw directly?
+
+While you can absolutely run bioformats2raw on its own or use the excellent [NGFF-Converter](https://github.com/glencoesoftware/NGFF-Converter) GUI, this pipeline has advantages in certain situtations:
+
+* **HPC Integration**: Easily schedules and distributes work on high-performance computing (HPC) clusters.
+* **Dependency Encapsulation**: No need to install or manage Java, Blosc, or other libraries. Everything runs in a controlled, containerized environment.
+* **Batch Processing**: Automatically scans and processes entire directories of images.
+* **Extended Features**: Includes Janelia-specific enhancements that may also benefit other users and facilities.
 
 ## Quick Start
 
-The only software requirements for running this pipeline are [Nextflow](https://www.nextflow.io) (version 20.10.0 or greater) and either [Docker](https://docs.docker.com/get-started/get-docker/) or [Singularity](https://sylabs.io) (version 3.5 or greater). If you are running on an HPC cluster, ask your system administrator to install Singularity on all the cluster nodes.
+The only software requirements for running this pipeline are [Nextflow](https://www.nextflow.io) (version 23.04.0 or greater) and either [Docker](https://docs.docker.com/get-started/get-docker/) or [Singularity/Apptainer](https://apptainer.org/). If you are running on an HPC cluster, ask your system administrator to install Apptainer on all the cluster nodes.
 
 To [install Nextflow](https://www.nextflow.io/docs/latest/getstarted.html):
 
@@ -16,22 +23,20 @@ Alternatively, you can install it as a conda package:
 
     conda create --name nextflow -c bioconda nextflow
 
-To [install Singularity](https://sylabs.io/guides/3.7/admin-guide/installation.html) on CentOS Linux:
+You can [install Apptainer](https://apptainer.org/docs/user/latest/quick_start.html#installation) by following the instructions for your platform.
 
-    sudo yum install singularity
-
-Now you can run the pipeline and it will download everything else it needs. Simply provide either a single image file or a directory containing image files.
+Now you can run the pipeline and it will download everything else it needs. Simply specify either a single image file or a directory containing image files.
 
 **For a single image file:**
 ```bash
     nextflow run JaneliaSciComp/nf-omezarr -profile singularity \
-        --input /path/to/image.czi --outdir ./output --cpus 40
+        --input /path/to/image.czi --outdir ./output 
 ```
 
 **For a directory containing multiple images:**
 ```bash
     nextflow run JaneliaSciComp/nf-omezarr -profile singularity \
-        --input /path/to/images/ --outdir ./output --cpus 40
+        --input /path/to/images/ --outdir ./output 
 ```
 
 The pipeline automatically detects all [Bioformats-compatible image files](https://docs.openmicroscopy.org/bio-formats/5.8.2/supported-formats.html) in the specified directory and processes each one. Supported formats include CZI, TIFF, LSM, ND2, LIF, IMS, VSI, and many others.
@@ -43,7 +48,9 @@ By default, the Zarr chunk size is set to 128,128,128. You can customize the chu
         --input /path/to/images/ --outdir ./output --chunk_size 1920,1920,1 
 ```
 
-This pipeline is [nf-core](https://nf-co.re/)-compatible and reuses pipeline infrastructure from the nf-core project, including the ability to use [nf-core institutional profiles](https://nf-co.re/configs/) that let you run on many university clusters without additional configuration. For example, to run this pipeline on the Janelia cluster: 
+The pipeline defaults to Blosc compression using LZ4 at compression level 6, which is the best all-around compression that we have found works for most types of microscopy data. You can customize this with the `--compression` and `--compression_properties` options. 
+
+This pipeline is [nf-core](https://nf-co.re/)-compatible and reuses pipeline infrastructure from the nf-core project, including the ability to use [nf-core institutional profiles](https://nf-co.re/configs/) that let you run on many university clusters without additional configuration. For example, to run this pipeline on the Janelia cluster, simply specify the Janelia profile: 
 
 ```bash
     nextflow run JaneliaSciComp/nf-omezarr -profile janelia \

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Now you can run the pipeline and it will download everything else it needs. Simp
 **For a single image file:**
 ```bash
     nextflow run JaneliaSciComp/nf-omezarr -profile singularity \
-        --input /path/to/image.czi --outdir ./output --compression zlib --cpus 40
+        --input /path/to/image.czi --outdir ./output --cpus 40
 ```
 
 **For a directory containing multiple images:**
 ```bash
     nextflow run JaneliaSciComp/nf-omezarr -profile singularity \
-        --input /path/to/images/ --outdir ./output --compression zlib --cpus 40
+        --input /path/to/images/ --outdir ./output --cpus 40
 ```
 
 The pipeline automatically detects all [Bioformats-compatible image files](https://docs.openmicroscopy.org/bio-formats/5.8.2/supported-formats.html) in the specified directory and processes each one. Supported formats include CZI, TIFF, LSM, ND2, LIF, IMS, VSI, and many others.
@@ -50,58 +50,77 @@ This pipeline is [nf-core](https://nf-co.re/)-compatible and reuses pipeline inf
          --input /path/to/images/ --outdir ./output
 ```
 
+## Pipeline options 
+ 
+Define the input data and bioformats2raw parameters. 
+ 
+| Parameter | Description | Type | Default | Required | Hidden | 
+|-----------|-----------|-----------|-----------|-----------|-----------| 
+| `input` | Path to input image file or directory containing image files to convert. <details><summary>Help</summary><small>Provide either a single image file in any 
+Bioformats-compatible format, or a directory containing multiple image files. If a directory is provided, all supported image files within it will be 
+processed.</small></details>| `string` | | True | | 
+| `outdir` | The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. | `string` | | True | | 
+| `memo_dir` | The directory where the temporary memo files will be saved. Default: outdir/tmp | `string` | | | True | 
+| `chunk_size` | Chunk size for Zarr in X,Y,Z order. Default: 128,128,128 | `string` | | | | 
+| `compression` | How the blocks will be compressed. Default: blosc | `string` | blosc | | | 
+| `compression_properties` | Comma-delimited compression properties for the blocks. Default: cname=lz4,clevel=6 | `string` | cname=lz4,clevel=6 | | | 
+| `overwrite` | Overwrite images in the output directory if they exists. Default: false | `boolean` | | | | 
+| `bioformats2raw_opts` | Extra options for Bioformats2raw | `string` | | | | 
+| `cpus` | Number of cores to allocate for bioformats2raw. Default: 10 | `integer` | | | | 
+| `memory` | Amount of memory to allocate for bioformats2raw. Default: 36.G | `string` | | | | 
+ 
+## Institutional config options 
+ 
+Parameters used to describe centralised config profiles. These should not be edited. 
+ 
+| Parameter | Description | Type | Default | Required | Hidden | 
+|-----------|-----------|-----------|-----------|-----------|-----------| 
+| `custom_config_version` | Git commit id for Institutional configs. | `string` | master | | True | 
+| `custom_config_base` | Base directory for Institutional configs. <details><summary>Help</summary><small>If you're running offline, Nextflow will not be able to fetch the 
+institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell 
+Nextflow where to find them with this parameter.</small></details>| `string` | https://raw.githubusercontent.com/nf-core/configs/master | | True | 
+| `config_profile_name` | Institutional config name. | `string` | | | True | 
+| `config_profile_description` | Institutional config description. | `string` | | | True | 
+| `config_profile_contact` | Institutional config contact information. | `string` | | | True | 
+| `config_profile_url` | Institutional config URL link. | `string` | | | True | 
+ 
+## Max job request options 
+ 
+Set the top limit for requested resources for any single job. 
+ 
+| Parameter | Description | Type | Default | Required | Hidden | 
+|-----------|-----------|-----------|-----------|-----------|-----------| 
+| `max_cpus` | Maximum number of CPUs that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the CPU requirement for
+each process. Should be an integer e.g. `--max_cpus 1`</small></details>| `integer` | 16 | | True | 
+| `max_memory` | Maximum amount of memory that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the memory 
+requirement for each process. Should be a string in the format integer-unit e.g. `--max_memory '8.GB'`</small></details>| `string` | 128.GB | | True | 
+| `max_time` | Maximum amount of time that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the time requirement 
+for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`</small></details>| `string` | 240.h | | True | 
+ 
+## Generic options 
+ 
+Less common options for the pipeline, typically set in a config file. 
+ 
+| Parameter | Description | Type | Default | Required | Hidden | 
+|-----------|-----------|-----------|-----------|-----------|-----------| 
+| `help` | Display help text. | `boolean` | | | True | 
+| `version` | Display version and exit. | `boolean` | | | True | 
+| `email` | Email address for completion summary. <details><summary>Help</summary><small>Set this parameter to your e-mail address to get a summary e-mail with details of 
+the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every 
+run.</small></details>| `string` | | | | 
+| `email_on_fail` | Email address for completion summary, only when pipeline fails. <details><summary>Help</summary><small>An email address to send a summary email to when 
+the pipeline is completed - ONLY sent if the pipeline does not exit successfully.</small></details>| `string` | | | True | 
+| `plaintext_email` | Send plain-text email instead of HTML. | `boolean` | | | True | 
+| `monochrome_logs` | Do not use coloured log outputs. | `boolean` | | | True | 
+| `hook_url` | Incoming hook URL for messaging service <details><summary>Help</summary><small>Incoming hook URL for messaging service. Currently, MS Teams and Slack are 
+supported.</small></details>| `string` | | | True | 
+| `validate_params` | Boolean whether to validate parameters against the schema at runtime | `boolean` | True | | True | 
+| `validationShowHiddenParams` | Show all params when using `--help` <details><summary>Help</summary><small>By default, parameters set as _hidden_ in the schema are not 
+shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters.</small></details>| `boolean` | | | True | 
+| `validationFailUnrecognisedParams` | Validation of parameters fails when an unrecognised parameter is found. <details><summary>Help</summary><small>By default, when an 
+unrecognised parameter is found, it returns a warinig.</small></details>| `boolean` | | | True | 
+| `validationLenientMode` | Validation of parameters in lenient more. <details><summary>Help</summary><small>Allows string values that are parseable as numbers or booleans.
+For further information see [JSONSchema docs](https://github.com/everit-org/json-schema#lenient-mode).</small></details>| `boolean` | | | True | 
+ 
 
-## Pipeline options
 
-Define the input data and bioformats2raw parameters.
-
-| Parameter | Description | Type | Default | Required | Hidden |
-|-----------|-----------|-----------|-----------|-----------|-----------|
-| `input` | Path to input image file or directory containing image files to convert. <details><summary>Help</summary><small>Provide either a single image file in any Bioformats-compatible format, or a directory containing multiple image files. If a directory is provided, all supported image files within it will be processed.</small></details>| `string` |  | True |  |
-| `outdir` | The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure. | `string` |  | True |  |
-| `bioformats2raw_opts` | Extra options for Bioformats2raw | `string` |  |  |  |
-| `chunk_size` | Chunk size for Zarr in X,Y,Z order. Default: 128,128,128 | `string` |  |  |  |
-| `compression` | How the blocks will be compressed. The default "blosc" compression uses LZ4. The "zlib" compression is slower but usually achieves a higher compression ratio. More information is available in the [https://jzarr.readthedocs.io/en/latest/tutorial.html#compressors](JZarr documentation). Default: blosc | `string` |  |  |  |
-| `cpus` | Number of cores to allocate for bioformats2raw. Default: 10 | `integer` |  |  |  |
-| `memory` | Amount of memory to allocate for bioformats2raw. Default: 36.G | `string` |  |  |  |
-
-## Institutional config options
-
-Parameters used to describe centralised config profiles. These should not be edited.
-
-| Parameter | Description | Type | Default | Required | Hidden |
-|-----------|-----------|-----------|-----------|-----------|-----------|
-| `custom_config_version` | Git commit id for Institutional configs. | `string` | master |  | True |
-| `custom_config_base` | Base directory for Institutional configs. <details><summary>Help</summary><small>If you're running offline, Nextflow will not be able to fetch the institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell Nextflow where to find them with this parameter.</small></details>| `string` | https://raw.githubusercontent.com/nf-core/configs/master |  | True |
-| `config_profile_name` | Institutional config name. | `string` |  |  | True |
-| `config_profile_description` | Institutional config description. | `string` |  |  | True |
-| `config_profile_contact` | Institutional config contact information. | `string` |  |  | True |
-| `config_profile_url` | Institutional config URL link. | `string` |  |  | True |
-
-## Max job request options
-
-Set the top limit for requested resources for any single job.
-
-| Parameter | Description | Type | Default | Required | Hidden |
-|-----------|-----------|-----------|-----------|-----------|-----------|
-| `max_cpus` | Maximum number of CPUs that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the CPU requirement for each process. Should be an integer e.g. `--max_cpus 1`</small></details>| `integer` | 16 |  | True |
-| `max_memory` | Maximum amount of memory that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the memory requirement for each process. Should be a string in the format integer-unit e.g. `--max_memory '8.GB'`</small></details>| `string` | 128.GB |  | True |
-| `max_time` | Maximum amount of time that can be requested for any single job. <details><summary>Help</summary><small>Use to set an upper-limit for the time requirement for each process. Should be a string in the format integer-unit e.g. `--max_time '2.h'`</small></details>| `string` | 240.h |  | True |
-
-## Generic options
-
-Less common options for the pipeline, typically set in a config file.
-
-| Parameter | Description | Type | Default | Required | Hidden |
-|-----------|-----------|-----------|-----------|-----------|-----------|
-| `help` | Display help text. | `boolean` |  |  | True |
-| `version` | Display version and exit. | `boolean` |  |  | True |
-| `email` | Email address for completion summary. <details><summary>Help</summary><small>Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.</small></details>| `string` |  |  |  |
-| `email_on_fail` | Email address for completion summary, only when pipeline fails. <details><summary>Help</summary><small>An email address to send a summary email to when the pipeline is completed - ONLY sent if the pipeline does not exit successfully.</small></details>| `string` |  |  | True |
-| `plaintext_email` | Send plain-text email instead of HTML. | `boolean` |  |  | True |
-| `monochrome_logs` | Do not use coloured log outputs. | `boolean` |  |  | True |
-| `hook_url` | Incoming hook URL for messaging service <details><summary>Help</summary><small>Incoming hook URL for messaging service. Currently, MS Teams and Slack are supported.</small></details>| `string` |  |  | True |
-| `validate_params` | Boolean whether to validate parameters against the schema at runtime | `boolean` | True |  | True |
-| `validationShowHiddenParams` | Show all params when using `--help` <details><summary>Help</summary><small>By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters.</small></details>| `boolean` |  |  | True |
-| `validationFailUnrecognisedParams` | Validation of parameters fails when an unrecognised parameter is found. <details><summary>Help</summary><small>By default, when an unrecognised parameter is found, it returns a warinig.</small></details>| `boolean` |  |  | True |
-| `validationLenientMode` | Validation of parameters in lenient more. <details><summary>Help</summary><small>Allows string values that are parseable as numbers or booleans. For further information see [JSONSchema docs](https://github.com/everit-org/json-schema#lenient-mode).</small></details>| `boolean` |  |  | True |

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,0 @@
-id,image,output_path,mip_xy
-file1,/path/to/bioformats/compatible/file1.tiff,/path/to/output,/path/to/xy/mip1.png
-file2,/path/to/bioformats/compatible/file2.tiff,path/to/output/relative/to/outdir,mip2.png
-file3,/path/to/bioformats/compatible/file3.tiff,,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -22,7 +22,8 @@ process {
 
     withName: BIOFORMATS2RAW {
         def chunkSize = params.chunk_size.split(',')
-        ext.args = "-w ${chunkSize[0]} -h ${chunkSize[1]} -z ${chunkSize[2]} --compression=${params.compression} ${params.bioformats2raw_opts}"
+        def overwrite = params.overwrite ? "--overwrite" : ""
+        ext.args = "-w ${chunkSize[0]} -h ${chunkSize[1]} -z ${chunkSize[2]} --compression=${params.compression} --compression-properties='${params.compression_properties}' ${overwrite} ${params.bioformats2raw_opts}"
         ext.cpus = "${params.cpus}"
         ext.memory = "${params.memory}"
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -23,7 +23,8 @@ process {
     withName: BIOFORMATS2RAW {
         def chunkSize = params.chunk_size.split(',')
         def overwrite = params.overwrite ? "--overwrite" : ""
-        ext.args = "-w ${chunkSize[0]} -h ${chunkSize[1]} -z ${chunkSize[2]} --compression=${params.compression} --compression-properties='${params.compression_properties}' ${overwrite} ${params.bioformats2raw_opts}"
+        def compressionProps = params.compression_properties ? params.compression_properties.split(',').collect { "--compression-properties='${it}'" }.join(' ') : ''
+        ext.args = "-w ${chunkSize[0]} -h ${chunkSize[1]} -z ${chunkSize[2]} --compression=${params.compression} ${compressionProps} ${overwrite} ${params.bioformats2raw_opts}"
         ext.cpus = "${params.cpus}"
         ext.memory = "${params.memory}"
     }

--- a/main.nf
+++ b/main.nf
@@ -57,6 +57,46 @@ log.info logo + paramsSummaryLog(workflow) + citation
 include { BIOFORMATS2RAW              } from './modules/janelia/bioformats2raw/main'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from './modules/nf-core/custom/dumpsoftwareversions/main'
 
+// Process to unwrap single-image outputs
+process UNWRAP_SINGLE_IMAGE {
+    tag "${meta.id}"
+    
+    input:
+    tuple val(meta),
+          path(input_image),
+          path(zarr_output_path)
+    
+    output:
+    tuple val(meta),
+          path(input_image),
+          path(zarr_output_path),
+          emit: unwrapped
+    
+    when:
+    params.unwrap == true
+    
+    script:
+    """
+    # Check if zarr output contains only '0' directory and no '1' directory
+    if [ -d "${zarr_output_path}/0" ] && [ ! -d "${zarr_output_path}/1" ]; then
+        echo "Single image detected in ${zarr_output_path}, unwrapping..."
+        
+        mv "${zarr_output_path}/0" "${zarr_output_path}/image"
+
+        # Move all contents from 0/ up one level, including hidden files
+        mv "${zarr_output_path}/image/"* "${zarr_output_path}/" 2>/dev/null || true
+        mv "${zarr_output_path}/image/".* "${zarr_output_path}/" 2>/dev/null || true
+
+        # Remove the now empty image directory
+        rmdir "${zarr_output_path}/image"
+
+        echo "Unwrapping completed for ${zarr_output_path}"
+    else
+        echo "Multiple images detected or no '0' directory found in ${zarr_output_path}, skipping unwrap"
+    fi
+    """
+}
+
 
 
 workflow TO_OMEZARR {
@@ -142,8 +182,11 @@ workflow TO_OMEZARR {
         def (meta, image, abs_output_path, memo_path) = it
         [meta, image, abs_output_path, memo_path]
     })
-    ch_versions = ch_versions.mix(BIOFORMATS2RAW.out.versions)
 
+    // Unwrap single-image outputs if requested
+    UNWRAP_SINGLE_IMAGE(BIOFORMATS2RAW.out.params)
+
+    ch_versions = ch_versions.mix(BIOFORMATS2RAW.out.versions)
     //
     // MODULE: Pipeline reporting
     //

--- a/main.nf
+++ b/main.nf
@@ -126,14 +126,17 @@ workflow TO_OMEZARR {
             def meta = [
                 id: imageFile.name.replaceAll(/\.[^.]+$/, '') // Remove file extension for ID
             ]
-            [meta, imageFile.getAbsolutePath(), params.outdir]
+            def memo_path = params.memo_dir ? params.memo_dir : params.outdir
+            // Create memo directory if it doesn't exist
+            new File(memo_path).mkdirs()
+            [meta, imageFile.getAbsolutePath(), params.outdir, memo_path]
         }
         .set { ch_input }
 
     // Convert to OME-Zarr
     BIOFORMATS2RAW(ch_input.map {
-        def (meta, image, abs_output_path) = it
-        [meta, image, abs_output_path]
+        def (meta, image, abs_output_path, memo_path) = it
+        [meta, image, abs_output_path, memo_path]
     })
     ch_versions = ch_versions.mix(BIOFORMATS2RAW.out.versions)
 

--- a/main.nf
+++ b/main.nf
@@ -55,49 +55,8 @@ log.info logo + paramsSummaryLog(workflow) + citation
 */
 
 include { BIOFORMATS2RAW              } from './modules/janelia/bioformats2raw/main'
+include { UNWRAP_SINGLE_IMAGE }         from './modules/local/unwrap/main'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from './modules/nf-core/custom/dumpsoftwareversions/main'
-
-// Process to unwrap single-image outputs
-process UNWRAP_SINGLE_IMAGE {
-    tag "${meta.id}"
-    
-    input:
-    tuple val(meta),
-          path(input_image),
-          path(zarr_output_path)
-    
-    output:
-    tuple val(meta),
-          path(input_image),
-          path(zarr_output_path),
-          emit: unwrapped
-    
-    when:
-    params.unwrap == true
-    
-    script:
-    """
-    # Check if zarr output contains only '0' directory and no '1' directory
-    if [ -d "${zarr_output_path}/0" ] && [ ! -d "${zarr_output_path}/1" ]; then
-        echo "Single image detected in ${zarr_output_path}, unwrapping..."
-        
-        mv "${zarr_output_path}/0" "${zarr_output_path}/image"
-
-        # Move all contents from 0/ up one level, including hidden files
-        mv "${zarr_output_path}/image/"* "${zarr_output_path}/" 2>/dev/null || true
-        mv "${zarr_output_path}/image/".* "${zarr_output_path}/" 2>/dev/null || true
-
-        # Remove the now empty image directory
-        rmdir "${zarr_output_path}/image"
-
-        echo "Unwrapping completed for ${zarr_output_path}"
-    else
-        echo "Multiple images detected or no '0' directory found in ${zarr_output_path}, skipping unwrap"
-    fi
-    """
-}
-
-
 
 workflow TO_OMEZARR {
     ch_versions = Channel.empty()
@@ -184,7 +143,9 @@ workflow TO_OMEZARR {
     })
 
     // Unwrap single-image outputs if requested
-    UNWRAP_SINGLE_IMAGE(BIOFORMATS2RAW.out.params)
+    if (params.unwrap) {
+        UNWRAP_SINGLE_IMAGE(BIOFORMATS2RAW.out.params)
+    }
 
     ch_versions = ch_versions.mix(BIOFORMATS2RAW.out.versions)
     //

--- a/main.nf
+++ b/main.nf
@@ -57,6 +57,8 @@ log.info logo + paramsSummaryLog(workflow) + citation
 include { BIOFORMATS2RAW              } from './modules/janelia/bioformats2raw/main'
 include { CUSTOM_DUMPSOFTWAREVERSIONS } from './modules/nf-core/custom/dumpsoftwareversions/main'
 
+
+
 workflow TO_OMEZARR {
     ch_versions = Channel.empty()
 
@@ -112,6 +114,8 @@ workflow TO_OMEZARR {
                         extension = "${parts[-2]}.${parts[-1]}"
                     }
                 }
+                // Convert from org.codehaus.groovy.runtime.GStringImpl to String, so that comparisons work
+                extension = extension.toString()
                 if (supportedExtensions.contains(extension)) {
                     return [inputFile.getAbsolutePath()]
                 } else {

--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
         "janelia": {
           "bioformats2raw": {
             "branch": "main",
-            "git_sha": "e0c672edffb31b7ee4114e5763c3f41a04bfbb9b",
+            "git_sha": "93b30afcfab9d8c3cb170f318d9d2c78c1e9e2bf",
             "installed_by": ["modules"]
           }
         }

--- a/modules/janelia/bioformats2raw/main.nf
+++ b/modules/janelia/bioformats2raw/main.nf
@@ -7,8 +7,8 @@ process BIOFORMATS2RAW {
     input:
     tuple val(meta),
           path(input_image),
-          path(output_path)
-
+          path(output_path),
+          path(memo_directory, stageAs: 'memo/*')
     output:
     tuple val(meta),
           path(input_image),
@@ -23,8 +23,22 @@ process BIOFORMATS2RAW {
     extra_args = task.ext.args ?: ''
     zarr_output_path = output_path.toString()+"/"+input_image.getBaseName()+".zarr"
     max_workers = extra_args.contains("--max-workers") ? "" : "--max-workers=$task.cpus"
+    memo_id = UUID.randomUUID().toString().substring(0,10)
     """
+    # Generate random sequence of 10 chars for memo directory name
+    MEMO_PATH="${memo_directory}/${memo_id}"
+    mkdir -p \$MEMO_PATH
+    echo "Created memo path: \$MEMO_PATH"
+
+    function cleanup() {
+        echo "Cleaning up memo directory \$MEMO_PATH"
+        rm -rf \$MEMO_PATH
+        exit 0
+    }
+    trap cleanup INT TERM EXIT
+
     /opt/bioformats2raw/bin/bioformats2raw \
+        --memo-directory \$MEMO_PATH \
         $max_workers \
         $extra_args \
         $input_image \

--- a/modules/janelia/bioformats2raw/meta.yml
+++ b/modules/janelia/bioformats2raw/meta.yml
@@ -11,15 +11,16 @@ input:
   - ch_meta:
       type: tuple
       description: |
-        Channel of tuples containing a meta map, the input image, and an 
-        output path where the OME-Zarr should be created.
-        Structure: [ val(meta), path(input_image), val(output_path) ]
+        Channel of tuples containing a meta map, the input image, an 
+        output path where the OME-Zarr should be created, and a memo directory
+        where temporary files will be saved.
+        Structure: [ val(meta), path(input_image), val(output_path), val(memo_directory) ]
 
 output:
   - params:
       type: tuple
       description: |
-        Same as the input tuple but replaces output path with the OME-Zarr that 
+        Same as the input tuple but replaces output paths with the OME-Zarr that 
         was created.
         Structure: [ val(meta), path(input_image), val(zarr_output_path) ]
   - versions:

--- a/modules/local/unwrap/main.nf
+++ b/modules/local/unwrap/main.nf
@@ -1,0 +1,37 @@
+
+// Process to unwrap single-image outputs
+process UNWRAP_SINGLE_IMAGE {
+    tag "${meta.id}"
+    
+    input:
+    tuple val(meta),
+          path(input_image),
+          path(zarr_output_path)
+    
+    output:
+    tuple val(meta),
+          path(input_image),
+          path(zarr_output_path),
+          emit: unwrapped
+    
+    script:
+    """
+    # Check if zarr output contains only '0' directory and no '1' directory
+    if [ -d "${zarr_output_path}/0" ] && [ ! -d "${zarr_output_path}/1" ]; then
+        echo "Single image detected in ${zarr_output_path}, unwrapping..."
+        
+        mv "${zarr_output_path}/0" "${zarr_output_path}/image"
+
+        # Move all contents from 0/ up one level, including hidden files
+        mv "${zarr_output_path}/image/"* "${zarr_output_path}/" 2>/dev/null || true
+        mv "${zarr_output_path}/image/".* "${zarr_output_path}/" 2>/dev/null || true
+
+        # Remove the now empty image directory
+        rmdir "${zarr_output_path}/image"
+
+        echo "Unwrapping completed for ${zarr_output_path}"
+    else
+        echo "Multiple images detected or no '0' directory found in ${zarr_output_path}, skipping unwrap"
+    fi
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,8 +19,8 @@ params {
     cpus                       = 10
     memory                     = '36.G'
     chunk_size                 = '128,128,128'
-    compression                = 'zlib'
-    compression_properties     = ''
+    compression                = 'blosc'
+    compression_properties     = 'cname=lz4,clevel=6'
     overwrite                  = false
     bioformats2raw_opts        = ''
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,8 @@ params {
     memory                     = '36.G'
     chunk_size                 = '128,128,128'
     compression                = 'zlib'
+    compression_properties     = ''
+    overwrite                  = false
     bioformats2raw_opts        = ''
 
     // Boilerplate options

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
     // Input options
     input                      = null
     outdir                     = null
+    memo_dir                   = null
     cpus                       = 10
     memory                     = '36.G'
     chunk_size                 = '128,128,128'

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
     compression_properties     = 'cname=lz4,clevel=6'
     overwrite                  = false
     bioformats2raw_opts        = ''
+    unwrap                     = true
 
     // Boilerplate options
     email                      = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -72,6 +72,12 @@
                     "help": "Options can be found here: https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java",
                     "fa_icon": "fas fa-terminal"
                 },
+                "unwrap": {
+                    "type": "boolean",
+                    "description": "Unwrap single-image outputs by moving contents of '0' directory up one level. Default: false",
+                    "help": "When enabled, if the output contains only a '0' directory and no '1' directory, the contents of the '0' directory will be moved up one level and the '0' directory will be removed.",
+                    "fa_icon": "fas fa-layer-group"
+                },
                 "cpus": {
                     "type": "integer",
                     "fa_icon": "fas fa-microchip",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -37,7 +37,8 @@
                 "compression": {
                     "type": "string",
                     "description": "How the blocks will be compressed. Default: blosc",
-                    "help": "Blosc (LZ4) compresses faster, Zlib compresses more.",
+                    "default": "blosc",
+                    "help": "When changing the compression, you also need to change the compression properties. See the bioformats2raw documentation for more details.",
                     "fa_icon": "fas fa-file-archive",
                     "enum": [
                         "zlib",
@@ -46,8 +47,9 @@
                 },
                 "compression_properties": {
                     "type": "string",
-                    "description": "Compression properties for the blocks. Default: empty",
-                    "help": "Compression properties for the blocks.",
+                    "description": "Comma-delimited compression properties for the blocks. Default: cname=lz4,clevel=6",
+                    "default": "cname=lz4,clevel=6",
+                    "help": "Compression properties for the blocks, formatted as 'key=value,key=value,...'. See the bioformats2raw documentation for more details.",
                     "fa_icon": "fas fa-align-justify"
                 },
                 "overwrite": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -26,7 +26,8 @@
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",
-                    "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
+                    "description": "The output directory where the results will be saved.",
+                    "help_text": "An output zarr directory will be created in this directory for each input image file. You have to use an absolute path to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
                 "memo_dir": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -37,6 +37,12 @@
                     "fa_icon": "fas fa-folder-open",
                     "hidden": true
                 },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Overwrite images in the output directory if they exists. Default: false",
+                    "help": "Enables the --overwrite option for bioformats2raw.",
+                    "fa_icon": "fas fa-edit"
+                },
                 "chunk_size": {
                     "type": "string",
                     "description": "Chunk size for Zarr in X,Y,Z order. Default: 128,128,128",
@@ -59,12 +65,6 @@
                     "default": "cname=lz4,clevel=6",
                     "help": "Compression properties for the blocks, formatted as 'key=value,key=value,...'. See the bioformats2raw documentation for more details.",
                     "fa_icon": "fas fa-align-justify"
-                },
-                "overwrite": {
-                    "type": "boolean",
-                    "description": "Overwrite images in the output directory if they exists. Default: false",
-                    "help": "Enables the --overwrite option for bioformats2raw.",
-                    "fa_icon": "fas fa-edit"
                 },
                 "bioformats2raw_opts": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -29,6 +29,13 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
+                "memo_dir": {
+                    "type": "string",
+                    "format": "directory-path",
+                    "description": "The directory where the temporary memo files will be saved. Default: outdir/tmp",
+                    "fa_icon": "fas fa-folder-open",
+                    "hidden": true
+                },
                 "chunk_size": {
                     "type": "string",
                     "description": "Chunk size for Zarr in X,Y,Z order. Default: 128,128,128",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -29,12 +29,6 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
-                "bioformats2raw_opts": {
-                    "type": "string",
-                    "description": "Extra options for Bioformats2raw",
-                    "help": "Options can be found here: https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java",
-                    "fa_icon": "fas fa-terminal"
-                },
                 "chunk_size": {
                     "type": "string",
                     "description": "Chunk size for Zarr in X,Y,Z order. Default: 128,128,128",
@@ -45,7 +39,28 @@
                     "description": "How the blocks will be compressed. Default: blosc",
                     "help": "Blosc (LZ4) compresses faster, Zlib compresses more.",
                     "fa_icon": "fas fa-file-archive",
-                    "enum": ["zlib", "blosc"]
+                    "enum": [
+                        "zlib",
+                        "blosc"
+                    ]
+                },
+                "compression_properties": {
+                    "type": "string",
+                    "description": "Compression properties for the blocks. Default: empty",
+                    "help": "Compression properties for the blocks.",
+                    "fa_icon": "fas fa-align-justify"
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Overwrite images in the output directory if they exists. Default: false",
+                    "help": "Enables the --overwrite option for bioformats2raw.",
+                    "fa_icon": "fas fa-edit"
+                },
+                "bioformats2raw_opts": {
+                    "type": "string",
+                    "description": "Extra options for Bioformats2raw",
+                    "help": "Options can be found here: https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java",
+                    "fa_icon": "fas fa-terminal"
                 },
                 "cpus": {
                     "type": "integer",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -74,9 +74,10 @@
                 },
                 "unwrap": {
                     "type": "boolean",
-                    "description": "Unwrap single-image outputs by moving contents of '0' directory up one level. Default: false",
+                    "description": "Unwrap single-image outputs by moving contents of '0' directory up one level. Default: true",
                     "help": "When enabled, if the output contains only a '0' directory and no '1' directory, the contents of the '0' directory will be moved up one level and the '0' directory will be removed.",
-                    "fa_icon": "fas fa-layer-group"
+                    "fa_icon": "fas fa-layer-group",
+                    "default": true
                 },
                 "cpus": {
                     "type": "integer",


### PR DESCRIPTION
I've made several improvements to this pipeline so that end users can easily run it on Seqera Platform:

* Improved documentation
* Exposed additional params including `--overwrite` and  `--compression`
* Changed default compression to LZ4
* Moved the default memo directory from /tmp, which causes issues on the Janelia cluster. 
* Bioformats2raw always creates a `0/` folder at the top level for single images. By default, this pipeline now unwraps those images by moving them up a level. This can be disabled with `--unwrap=false`

@StephanPreibisch @cgoina 